### PR TITLE
fix: calculate output image size not depending on scale/crs

### DIFF
--- a/translator/raster/wms.py
+++ b/translator/raster/wms.py
@@ -1,48 +1,17 @@
 import os
 
 from qgis.core import (
-    QgsCoordinateReferenceSystem,
     QgsProject,
     QgsRasterFileWriter,
     QgsRasterLayer,
     QgsRasterPipe,
     QgsRectangle,
-    Qgis,
     QgsCoordinateTransform,
 )
 from qgis.utils import iface
 import processing
 
 from utils import get_tempdir
-
-
-def _get_multiplier_by_unit_of(crs: QgsCoordinateReferenceSystem) -> float:
-    """return multiplier: crs unit -> inch"""
-    if crs.mapUnits() == Qgis.DistanceUnit.Meters:
-        multiplier_to_meter = 1.0
-    elif crs.mapUnits() == Qgis.DistanceUnit.Kilometers:
-        multiplier_to_meter = 1000.0
-    elif crs.mapUnits() == Qgis.DistanceUnit.Feet:
-        multiplier_to_meter = 0.3048
-    elif crs.mapUnits() == Qgis.DistanceUnit.NauticalMiles:
-        multiplier_to_meter = 1852.0
-    elif crs.mapUnits() == Qgis.DistanceUnit.Yards:
-        multiplier_to_meter = 0.9144
-    elif crs.mapUnits() == Qgis.DistanceUnit.Miles:
-        multiplier_to_meter = 1609.344
-    elif crs.mapUnits() == Qgis.DistanceUnit.Degrees:
-        multiplier_to_meter = 111319.49079327358  # at equator
-    elif crs.mapUnits() == Qgis.DistanceUnit.Centimeters:
-        multiplier_to_meter = 0.01
-    elif crs.mapUnits() == Qgis.DistanceUnit.Millimeters:
-        multiplier_to_meter = 0.001
-    elif crs.mapUnits() == Qgis.DistanceUnit.Inches:
-        multiplier_to_meter = 0.0254
-    else:
-        multiplier_to_meter = 1.0  # fallback
-
-    multiplier_to_inch = multiplier_to_meter / 0.0254
-    return multiplier_to_inch
 
 
 def process_wms(layer: QgsRasterLayer, extent: QgsRectangle, idx: int, output_dir: str):
@@ -56,15 +25,14 @@ def process_wms(layer: QgsRasterLayer, extent: QgsRectangle, idx: int, output_di
     )
     extent_in_layer_crs = transform.transformBoundingBox(extent)
 
-    # Calculate image size in pixels
-    dpi = iface.mapCanvas().mapSettings().outputDpi()  # dots / inch
-    inch_to_crs_unit = _get_multiplier_by_unit_of(QgsProject.instance().crs())
     # xy length in project-crs unit
     extent_width = extent.xMaximum() - extent.xMinimum()
     extent_height = extent.yMaximum() - extent.yMinimum()
-    # length_in_dots = length_in_crs_unit / (dpm = dpi/inch_to_crs_unit)
-    image_width = int(extent_width / dpi * inch_to_crs_unit)
-    image_height = int(extent_height / dpi * inch_to_crs_unit)
+
+    # calculate image size: same to map canvas
+    units_per_pixel = iface.mapCanvas().mapUnitsPerPixel()
+    image_width = int(extent_width / units_per_pixel)
+    image_height = int(extent_height / units_per_pixel)
 
     # export layer as tiff
     tiff_path = os.path.join(get_tempdir(output_dir), f"layer_{idx}.tiff")


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #74 
close #50 
close #51 

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- before: calculate image size by extent, dpi and `scale`
- after: calculate image size by extent and dpi

## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
- Check that wms layer is exported in a reasonable resolution for mapCanvas DPI.

## その他:Notes
<!-- 重点的に見てほしい点など、何かあれば書く -->
- 特になし