### PR TITLE
make work with expression based calculated attributes

### DIFF
--- a/translator/vector/process.py
+++ b/translator/vector/process.py
@@ -61,6 +61,33 @@ def _get_layer_type(layer: QgsVectorLayer):
         return "unsupported"
 
 
+def _preprocess_layer(
+    layer: QgsVectorLayer, extent: QgsRectangle
+) -> (QgsVectorLayer, str):
+    """clip and calculate on-the-fly attribute
+    layer -> clip by extent -> if has on-the-fly attribute, calculate it -> return
+    """
+    layer_clipped = _clip_in_projectcrs(layer, extent)
+
+    if layer.renderer().classAttribute() in layer.fields().names():
+        return layer_clipped, layer.renderer().classAttribute()
+    else:
+        target_field = "tmp_calc"
+        calculated_layer = processing.run(
+            "native:fieldcalculator",
+            {
+                "INPUT": layer_clipped,
+                "FIELD_NAME": target_field,
+                "FIELD_TYPE": _get_field_value_type(layer),
+                "FIELD_LENGTH": 0,
+                "FIELD_PRECISION": 0,
+                "FORMULA": f"{layer.renderer().classAttribute()}",
+                "OUTPUT": "TEMPORARY_OUTPUT",
+            },
+        )["OUTPUT"]
+        return calculated_layer, target_field
+
+
 def _get_field_value_type(layer: QgsVectorLayer) -> int:
     if layer.renderer().type() == "categorizedSymbol":
         # enum for calculate field class
@@ -75,37 +102,6 @@ def _get_field_value_type(layer: QgsVectorLayer) -> int:
     elif layer.renderer().type() == "graduatedSymbol":
         # graduated ranges are float values
         return 0
-
-
-def _calculate_layer_expression(
-    target_layer: QgsVectorLayer, reference_layer: QgsVectorLayer, target_field: str
-) -> QgsVectorLayer:
-    """
-    add an attribute to target_layer and calculate
-    using attribute expression set in reference_layer
-
-    Args:
-        target_layer (QgsVectorLayer): layer to edit
-        reference_layer (QgsVectorLayer):
-            layer where is set attribute expression and its type
-        target_field (str): attribute to be added and calculated
-
-    Returns:
-        calculated_layer (QgsVectorLayer): target_layer with calculated attribute
-    """
-    calculated_layer = processing.run(
-        "native:fieldcalculator",
-        {
-            "INPUT": target_layer,
-            "FIELD_NAME": target_field,
-            "FIELD_TYPE": _get_field_value_type(reference_layer),
-            "FIELD_LENGTH": 0,
-            "FIELD_PRECISION": 0,
-            "FORMULA": f"{reference_layer.renderer().classAttribute()}",
-            "OUTPUT": "TEMPORARY_OUTPUT",
-        },
-    )["OUTPUT"]
-    return calculated_layer
 
 
 def process_vector(
@@ -124,18 +120,8 @@ def process_vector(
 def _process_categorical(
     layer: QgsVectorLayer, extent: QgsRectangle, idx: int, output_dir: str
 ) -> dict:
-    layer_intersected = _clip_in_projectcrs(layer, extent)
+    layer_normalized, target_field = _preprocess_layer(layer, extent)
     has_unsupported_symbol = False
-
-    # determine class attribute
-    if layer.renderer().classAttribute() in layer.fields().names():
-        target_field = layer.renderer().classAttribute()
-    else:
-        target_field = "tmp_calc"
-
-        layer_intersected = _calculate_layer_expression(
-            layer_intersected, layer, target_field
-        )
 
     for sub_idx, category in enumerate(layer.renderer().categories()):
         # shp
@@ -152,7 +138,7 @@ def _process_categorical(
         filtered_features = list(
             filter(
                 lambda f: f[target_field] == category.value(),
-                layer_intersected.getFeatures(),
+                layer_normalized.getFeatures(),
             )
         )
         output_layer.addFeatures(filtered_features)
@@ -192,18 +178,8 @@ def _process_categorical(
 def _process_graduated(
     layer: QgsVectorLayer, extent: QgsRectangle, idx: int, output_dir: str
 ) -> dict:
-    layer_intersected = _clip_in_projectcrs(layer, extent)
+    layer_normalized, target_field = _preprocess_layer(layer, extent)
     has_unsupported_symbol = False
-
-    # determine class attribute
-    if layer.renderer().classAttribute() in layer.fields().names():
-        target_field = layer.renderer().classAttribute()
-    else:
-        target_field = "tmp_calc"
-
-        layer_intersected = _calculate_layer_expression(
-            layer_intersected, layer, target_field
-        )
 
     for sub_idx, range in enumerate(layer.renderer().ranges()):
         # shp
@@ -217,11 +193,14 @@ def _process_graduated(
             "ESRI Shapefile",
         )
 
-        # extract features by range
+        # filter features
+        # 1: filter out null value: on-the-fly attribute may have null value
+        # 2: extract features by range
         filtered_features = list(
             filter(
-                lambda f: range.lowerValue() < f[target_field] <= range.upperValue(),
-                layer_intersected.getFeatures(),
+                lambda f: f[target_field] is not None
+                and range.lowerValue() < f[target_field] <= range.upperValue(),
+                layer_normalized.getFeatures(),
             )
         )
         output_layer.addFeatures(filtered_features)


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #108 

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- タイトルのとおり

## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
Run and check Json AND shapefiles of below cases:
- Categorized, field attribute (for control)
- Graduated, field attribute (for control)
- Categorized, expression attribute (make integer value classification)
- Categorized, expression attribute (make float value classification)
- Categorized, expression attribute (make text value classification)
- Graduated, expression attribute (make float value classification)

Expression example to make string for mesh layer in crash_test project:
` to_string(round(   "OBJ_ID"  /20000)) ||  'a'"MESH5_ID"`

![image](https://github.com/MIERUNE/qgis-plugin-for-plugx/assets/26103833/9dde5bc3-1011-4da2-b925-3f44e50f3ea2)

