### PR TITLE
Fix/all other values categories

### DIFF
--- a/translator/vector/process.py
+++ b/translator/vector/process.py
@@ -142,14 +142,20 @@ def _process_categorical(
         )
         # extract features by category
         if category.value() == "" or category.value() == NULL:
-            # all other values
+            # all other values (defined with "" or NULL value)
 
-            category_list = [cat.value() for cat in layer.renderer().categories()]
-            category_values = list(filter(None, category_list))
+            # get list of all defined category values
+            #  → [1, 2, 4, '', NULL]
+            category_values = [cat.value() for cat in layer.renderer().categories()]
 
+            # List unempty category values (remove NULL and '' values)
+            #  → [1, 2, 4]
+            exclude_values = list(filter(None, category_values))
+
+            # Get features excluding unempty defined category values (5, 9, '', etc.)
             filtered_features = list(
                 filter(
-                    lambda f: f[target_field] not in category_values,
+                    lambda f: f[target_field] not in exclude_values,
                     layer_normalized.getFeatures(),
                 )
             )


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #49 

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- タイトルのとおり

## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
- Test with categorized symbols containing features included in 'all other values '
- check if all other values features are exported in exported shapefile

## その他:Notes
<!-- 重点的に見てほしい点など、何かあれば書く -->
all other values is detectable as `''` or as `NULL` category value
https://github.com/MIERUNE/qgis-plugin-for-plugx/issues/49#issuecomment-1667183921

when category.value() == NULL
QGIS system considers True `category.value() == NULL`
but not `category.value() is None` or `category.value() is NULL`

used `category.dump()` approach instead.