### PR TITLE
Handle hairline

### DIFF
--- a/translator/vector/symbol/fill.py
+++ b/translator/vector/symbol/fill.py
@@ -1,7 +1,6 @@
 from qgis.core import QgsSymbolLayer
-from plugx_utils import convert_to_point
 from PyQt5.QtCore import Qt
-from translator.vector.symbol.utils import to_rgba
+from translator.vector.symbol.utils import to_rgba, get_stroke_width_pt
 from translator.vector.symbol.penstyle import get_penstyle_from
 
 
@@ -37,7 +36,7 @@ def get_polygon_symbol_data(
             "color": to_rgba(symbol_layer.fillColor()),
             "brushstyle": _get_brushstyle_from(symbol_layer.brushStyle()),
             "outline_color": to_rgba(symbol_layer.strokeColor()),
-            "outline_width": convert_to_point(
+            "outline_width": get_stroke_width_pt(
                 symbol_layer.strokeWidth(), symbol_layer.strokeWidthUnit()
             ),
             "outline_penstyle": get_penstyle_from(symbol_layer),
@@ -84,7 +83,7 @@ def get_polygon_symbol_data(
             "type": "svg",
             "color": to_rgba(symbol_layer.color()),
             "outline_color": to_rgba(symbol_layer.svgStrokeColor()),
-            "outline_width": convert_to_point(
+            "outline_width": get_stroke_width_pt(
                 symbol_layer.svgStrokeWidth(), symbol_layer.svgStrokeWidthUnit()
             ),
             "level": symbol_layer.renderingPass(),

--- a/translator/vector/symbol/line.py
+++ b/translator/vector/symbol/line.py
@@ -12,7 +12,9 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
             "type": "simple",
             "color": to_rgba(symbol_layer.color()),
             "penstyle": get_penstyle_from(symbol_layer),
-            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(
+                symbol_layer.width(), symbol_layer.widthUnit()
+            ),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -22,7 +24,9 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         symbol_layer_dict = {
             "type": "interpolated",
             "color": to_rgba(symbol_layer.color()),
-            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(
+                symbol_layer.width(), symbol_layer.widthUnit()
+            ),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -50,7 +54,9 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "raster",
-            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(
+                symbol_layer.width(), symbol_layer.widthUnit()
+            ),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -58,7 +64,9 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "lineburst",
-            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(
+                symbol_layer.width(), symbol_layer.widthUnit()
+            ),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -66,7 +74,9 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "arrow",
-            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(
+                symbol_layer.width(), symbol_layer.widthUnit()
+            ),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }

--- a/translator/vector/symbol/line.py
+++ b/translator/vector/symbol/line.py
@@ -2,7 +2,7 @@ from qgis.core import QgsSymbolLayer
 from plugx_utils import convert_to_point
 
 from .marker import get_point_symbol_data
-from translator.vector.symbol.utils import to_rgba
+from translator.vector.symbol.utils import to_rgba, get_stroke_width_pt
 from translator.vector.symbol.penstyle import get_penstyle_from
 
 
@@ -12,7 +12,7 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
             "type": "simple",
             "color": to_rgba(symbol_layer.color()),
             "penstyle": get_penstyle_from(symbol_layer),
-            "width": convert_to_point(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -22,7 +22,7 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         symbol_layer_dict = {
             "type": "interpolated",
             "color": to_rgba(symbol_layer.color()),
-            "width": convert_to_point(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -50,7 +50,7 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "raster",
-            "width": convert_to_point(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -58,7 +58,7 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "lineburst",
-            "width": convert_to_point(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }
@@ -66,7 +66,7 @@ def get_line_symbol_data(symbol_layer: QgsSymbolLayer, symbol_opacity: float) ->
         # TODO: implement
         symbol_layer_dict = {
             "type": "arrow",
-            "width": convert_to_point(symbol_layer.width(), symbol_layer.widthUnit()),
+            "width": get_stroke_width_pt(symbol_layer.width(), symbol_layer.widthUnit()),
             "level": symbol_layer.renderingPass(),
             "opacity": symbol_opacity,
         }

--- a/translator/vector/symbol/marker.py
+++ b/translator/vector/symbol/marker.py
@@ -9,7 +9,7 @@ from PyQt5.QtGui import QColor
 from typing import Union, Tuple
 
 from plugx_utils import convert_to_point
-from translator.vector.symbol.utils import get_asset_name, to_rgba
+from translator.vector.symbol.utils import get_asset_name, to_rgba, get_stroke_width_pt
 from translator.vector.symbol.penstyle import get_penstyle_from
 
 
@@ -174,7 +174,7 @@ def get_point_symbol_data(
             "size": convert_to_point(symbol_layer.size(), symbol_layer.sizeUnit()),
             "color": to_rgba(symbol_layer.color()),
             "outline_color": to_rgba(symbol_layer.strokeColor()),
-            "outline_width": convert_to_point(
+            "outline_width": get_stroke_width_pt(
                 symbol_layer.strokeWidth(), symbol_layer.strokeWidthUnit()
             ),
             "outline_penstyle": get_penstyle_from(symbol_layer),

--- a/translator/vector/symbol/utils.py
+++ b/translator/vector/symbol/utils.py
@@ -4,6 +4,7 @@ from qgis.core import QgsSymbolLayer, QgsUnitTypes
 from PyQt5.QtGui import QColor
 from plugx_utils import convert_to_point
 
+
 def get_asset_dir(output_dir: str):
     return os.path.join(output_dir, "assets")
 
@@ -20,14 +21,16 @@ def to_rgba(color: QColor):
 
     return f"{color.name()}{alpha}"
 
+
 def get_stroke_width_pt(defined_width: float, unit: QgsUnitTypes.RenderUnit) -> float:
-    """ get line width in points, considering hairline or not 
+    """get line width in points, considering hairline or not
     symbol layer stroke width is set as 0 when hairline
     to be render as 0.5px (0.375pt) as defined in QGIS code
     https://github.com/qgis/QGIS/blob/e7f5b6f286b6cbaeaad5e73d69fad1448018c7e0/
     tests/src/python/test_qgssymbollayer_createsld.py#L234
     """
     if defined_width == 0:
-        return 0.375 # pt (hairline size: 0.5px)
+        hairline_px_size = 0.5
+        return convert_to_point(hairline_px_size, QgsUnitTypes.RenderPixels)
     else:
         return convert_to_point(defined_width, unit)

--- a/translator/vector/symbol/utils.py
+++ b/translator/vector/symbol/utils.py
@@ -1,8 +1,8 @@
 import os
 
-from qgis.core import QgsSymbolLayer
+from qgis.core import QgsSymbolLayer, QgsUnitTypes
 from PyQt5.QtGui import QColor
-
+from plugx_utils import convert_to_point
 
 def get_asset_dir(output_dir: str):
     return os.path.join(output_dir, "assets")
@@ -19,3 +19,15 @@ def to_rgba(color: QColor):
     alpha = hex(int(color.alphaF() * 255))[2:].zfill(2)
 
     return f"{color.name()}{alpha}"
+
+def get_stroke_width_pt(defined_width: float, unit: QgsUnitTypes.RenderUnit) -> float:
+    """ get line width in points, considering hairline or not 
+    symbol layer stroke width is set as 0 when hairline
+    to be render as 0.5px (0.375pt) as defined in QGIS code
+    https://github.com/qgis/QGIS/blob/e7f5b6f286b6cbaeaad5e73d69fad1448018c7e0/
+    tests/src/python/test_qgssymbollayer_createsld.py#L234
+    """
+    if defined_width == 0:
+        return 0.375 # pt (hairline size: 0.5px)
+    else:
+        return convert_to_point(defined_width, unit)


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #167

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- Hairline is set as symbol_layer.width() = 0 when export.
- Set as 0.375pt (0.5px) as QGIS defined. https://github.com/qgis/QGIS/blob/e7f5b6f286b6cbaeaad5e73d69fad1448018c7e0/tests/src/python/test_qgssymbollayer_createsld.py#L234


## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
- Make hairline on point , line and polygon layer and export json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - `fill.py`および`line.py`モジュールで`convert_to_point`関数を`get_stroke_width_pt`関数に置き換えました。
    - `line.py`で`to_rgba`関数のインポートを`to_rgba, get_stroke_width_pt`に置き換えました。
    - `marker.py`で`translator.vector.symbol.utils`から`get_stroke_width_pt`関数を追加しました。
- **リファクタ**
    - `get_stroke_width_pt`関数を導入して、ライン幅をポイント単位で計算するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->