### PR TITLE
Handle custom dash pattern 

### DIFF
--- a/translator/vector/symbol/penstyle.py
+++ b/translator/vector/symbol/penstyle.py
@@ -119,24 +119,26 @@ def _get_penstyle_from_line(symbol_layer: QgsLineSymbolLayer) -> dict:
 
     # dash pattern
     if penstyle["stroke"] == "dash":
-        if symbol_layer.useCustomDashPattern():
-            dash_pattern = [
-                convert_to_point(dash_value, symbol_layer.customDashPatternUnit())
-                for dash_value in symbol_layer.customDashVector()
-            ]
-        else:
-            # preset dash pattern: each value is multiplier to width
-            dash_pattern_mul = PRESET_DASHPATTERN_MULTIPLIER.get(
-                symbol_layer.penStyle(),
-                PRESET_DASHPATTERN_MULTIPLIER[Qt.DashLine],  # fallback
-            )
-            # as real length, in point
-            dash_pattern = [
-                dash_value
-                * convert_to_point(symbol_layer.width(), symbol_layer.widthUnit())
-                for dash_value in dash_pattern_mul
-            ]
+        # preset dash pattern: each value is multiplier to width
+        dash_pattern_mul = PRESET_DASHPATTERN_MULTIPLIER.get(
+            symbol_layer.penStyle(),
+            PRESET_DASHPATTERN_MULTIPLIER[Qt.DashLine],  # fallback
+        )
+        # as real length, in point
+        dash_pattern = [
+            dash_value
+            * convert_to_point(symbol_layer.width(), symbol_layer.widthUnit())
+            for dash_value in dash_pattern_mul
+        ]
 
-        penstyle["dash_pattern"] = dash_pattern
+    elif penstyle["stroke"] == "solid" and symbol_layer.useCustomDashPattern():
+        # customized patterns occurs NOT with dash strole but solid stroke
+        penstyle["stroke"] = "dash"
+        dash_pattern = [
+            convert_to_point(dash_value, symbol_layer.customDashPatternUnit())
+            for dash_value in symbol_layer.customDashVector()
+        ]
+
+    penstyle["dash_pattern"] = dash_pattern
 
     return penstyle

--- a/translator/vector/symbol/penstyle.py
+++ b/translator/vector/symbol/penstyle.py
@@ -119,17 +119,24 @@ def _get_penstyle_from_line(symbol_layer: QgsLineSymbolLayer) -> dict:
 
     # dash pattern
     if penstyle["stroke"] == "dash":
-        # preset dash pattern: each value is multiplier to width
-        dash_pattern_mul = PRESET_DASHPATTERN_MULTIPLIER.get(
-            symbol_layer.penStyle(),
-            PRESET_DASHPATTERN_MULTIPLIER[Qt.DashLine],  # fallback
-        )
-        # as real length, in point
-        dash_pattern = [
-            dash_value
-            * convert_to_point(symbol_layer.width(), symbol_layer.widthUnit())
-            for dash_value in dash_pattern_mul
-        ]
+        if symbol_layer.useCustomDashPattern():
+            dash_pattern = [
+                convert_to_point(dash_value, symbol_layer.customDashPatternUnit())
+                for dash_value in symbol_layer.customDashVector()
+            ]
+
+        else:
+            # preset dash pattern: each value is multiplier to width
+            dash_pattern_mul = PRESET_DASHPATTERN_MULTIPLIER.get(
+                symbol_layer.penStyle(),
+                PRESET_DASHPATTERN_MULTIPLIER[Qt.DashLine],  # fallback
+            )
+            # as real length, in point
+            dash_pattern = [
+                dash_value
+                * convert_to_point(symbol_layer.width(), symbol_layer.widthUnit())
+                for dash_value in dash_pattern_mul
+            ]
 
     elif penstyle["stroke"] == "solid" and symbol_layer.useCustomDashPattern():
         # customized patterns occurs NOT with dash strole but solid stroke


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #172

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- Preset dashed line was ok but not customized dashed
<img width="822" alt="image" src="https://github.com/MIERUNE/qgis-plugx-plugin/assets/26103833/5a65a565-93ef-4468-9210-f86f651325f1">

<img width="1147" alt="image" src="https://github.com/MIERUNE/qgis-plugx-plugin/assets/26103833/15550467-b26c-46e8-b50b-f200e5c86f3d">

<img width="777" alt="image" src="https://github.com/MIERUNE/qgis-plugx-plugin/assets/26103833/2d8bc88f-d9cd-48da-a868-8b026725e2ef">



## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
- Above style to be set (with custom dash pattern) and check if pattern is exported in layer_{n}.json

<img width="696" alt="image" src="https://github.com/MIERUNE/qgis-plugx-plugin/assets/26103833/2e40cbf6-3668-47b3-94a6-91f1f9dcaa14">

