### PR TITLE
Debug simple line fallback

### DIFF
--- a/translator/vector/symbol/penstyle.py
+++ b/translator/vector/symbol/penstyle.py
@@ -137,6 +137,7 @@ def _get_penstyle_from_line(symbol_layer: QgsLineSymbolLayer) -> dict:
                 * convert_to_point(symbol_layer.width(), symbol_layer.widthUnit())
                 for dash_value in dash_pattern_mul
             ]
+        penstyle["dash_pattern"] = dash_pattern
 
     elif penstyle["stroke"] == "solid" and symbol_layer.useCustomDashPattern():
         # customized patterns occurs NOT with dash strole but solid stroke
@@ -146,6 +147,6 @@ def _get_penstyle_from_line(symbol_layer: QgsLineSymbolLayer) -> dict:
             for dash_value in symbol_layer.customDashVector()
         ]
 
-    penstyle["dash_pattern"] = dash_pattern
+        penstyle["dash_pattern"] = dash_pattern
 
     return penstyle


### PR DESCRIPTION
<!-- /.github/pull_request_template.md -->
## Issue
<!-- close or related -->
close #0

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
Simple line が設定されるときのデバッグ
```
お世話になっております。
QGISプラグインv0.1.3につきまして、試用されたお客様から連絡がありました。ラインのシンボロジ設定で、dash patternを使わない単純な直線などの場合に、添付画像のようなエクスポートエラーが発生するようです。ご確認いただけますでしょうか。
お手数をお掛けいたします
```
![image](https://github.com/user-attachments/assets/2a8c5b4b-c590-4364-b55b-0fb1c240abcc)


## テスト手順:Test
<!-- なるべく自動テストに任せつつ、手動テストが必要なら記載 -->
- 以下の3つのパターンを出力してみる
- Solid Stroke style / No custom dash pattern (バッグあったやつ)
- Solid Stroke style / Custom dash pattern
- Dashed Stroke style
<img width="832" alt="image" src="https://github.com/user-attachments/assets/5b311d8c-6cd5-49a2-8eff-30bc00e723e8">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善された機能**
  - ペンスタイルの処理ロジックを簡素化し、ダッシュパターンの設定を一貫性のあるものにしました。これにより、シンボルレイヤー処理時の流れが明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->